### PR TITLE
Fixed parsing errors to show semantic analysis errors

### DIFF
--- a/erroneous/error008.txt
+++ b/erroneous/error008.txt
@@ -1,4 +1,4 @@
-// error program: parser errors. '=' on line30 and no '.' at end
+// error program: redefine function
 main
 var i,j;
 
@@ -27,8 +27,8 @@ function sum_to_n(still_n)
 };
 
 {
-    let i = 10;
+    let i := 10;
     call OutputNum(call sum_to_n(i));
     call OutputNum(call sum_to_n(i*2+j));
     call OutputNewLine();
-}
+}.


### PR DESCRIPTION
At least my compiler doesn't allow you to proceed to CFG generation and semantic analysis unless there are no semantic or parsing errors. I have fixed this program to remove the parsing errors, so I can show the semantic error of function redefinition.